### PR TITLE
changed target value to fix issue with 0.14.x typedoc

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "removeComments": true,
     "sourceMap": false,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "es2016",
       "dom"


### PR DESCRIPTION
While using your plugin with typedoc 0.14.2 I was getting `TypeError: Class constructor ConverterComponent cannot be invoked without 'new'` which I resolved by cloning your repo and creating the dist locally with es6 as the target. This seems like it's probably related to https://github.com/TypeStrong/typedoc/issues/943